### PR TITLE
Bugs in CacheHelper

### DIFF
--- a/core/src/main/java/com/douban/rexxar/resourceproxy/cache/CacheHelper.java
+++ b/core/src/main/java/com/douban/rexxar/resourceproxy/cache/CacheHelper.java
@@ -109,7 +109,7 @@ public class CacheHelper {
         if (TextUtils.isEmpty(url)) {
             return null;
         }
-        url = Uri.parse(url).buildUpon().clearQuery().build().toString();
+//        url = Uri.parse(url).buildUpon().clearQuery().build().toString();
         if (!checkUrl(url)) {
             return null;
         }


### PR DESCRIPTION
Bugs in CacheHelper. Page url with params cannot be found by method findHtmlCache in cache. Such as http://xx.xx.xx.xx/index.html?test=hello