### PR TITLE
RexxarContainerAPI由全局注册共享改为webview单独注册

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Demo 中使用 github 的 raw 文件服务提供一个简单的路由表文件 r
 #### gradle
 
 ```groovy
-   compile 'com.douban.rexxar:core:0.2.4'
+   compile 'com.douban.rexxar:core:0.2.5'
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Demo 中使用 github 的 raw 文件服务提供一个简单的路由表文件 r
 #### gradle
 
 ```groovy
-   compile 'com.douban.rexxar:core:0.2.1'
+   compile 'com.douban.rexxar:core:0.2.4'
 ```
 
 

--- a/core/gradle.properties
+++ b/core/gradle.properties
@@ -1,5 +1,5 @@
 PROJ_GROUP=com.douban.rexxar
-PROJ_VERSION=0.2.4
+PROJ_VERSION=0.2.5
 PROJ_NAME=rexxar-android
 PROJ_WEBSITEURL=https://github.com/douban/rexxar-android
 PROJ_ISSUETRACKERURL=https://github.com/douban/rexxar-android/issues

--- a/core/gradle.properties
+++ b/core/gradle.properties
@@ -1,5 +1,5 @@
 PROJ_GROUP=com.douban.rexxar
-PROJ_VERSION=0.2.3
+PROJ_VERSION=0.2.4
 PROJ_NAME=rexxar-android
 PROJ_WEBSITEURL=https://github.com/douban/rexxar-android
 PROJ_ISSUETRACKERURL=https://github.com/douban/rexxar-android/issues

--- a/core/src/main/java/com/douban/rexxar/resourceproxy/network/NetworkImpl.java
+++ b/core/src/main/java/com/douban/rexxar/resourceproxy/network/NetworkImpl.java
@@ -24,11 +24,7 @@ public class NetworkImpl implements INetwork {
     @Override
     public Response handle(Request request) throws IOException {
         try {
-            Response response = RexxarContainerAPIHelper.handle(request);
-            if (null == response) {
-                response = mOkHttpClient.newCall(request).execute();
-            }
-            return response;
+            return mOkHttpClient.newCall(request).execute();
         } catch (Exception e) {
             throw new IOException(e);
         }

--- a/core/src/main/java/com/douban/rexxar/resourceproxy/network/RexxarContainerAPIHelper.java
+++ b/core/src/main/java/com/douban/rexxar/resourceproxy/network/RexxarContainerAPIHelper.java
@@ -16,22 +16,11 @@ import okhttp3.Response;
  */
 public class RexxarContainerAPIHelper {
 
-    private static List<RexxarContainerAPI> mAPIS = new ArrayList<>();
-
-    public static void registerAPI(RexxarContainerAPI api) {
-        if (null != api) {
-            mAPIS.add(api);
+    public static Response handle(Request request, List<RexxarContainerAPI> containerAPIs) {
+        if (null == containerAPIs) {
+            return null;
         }
-    }
-
-    public static void registerAPIs(List<RexxarContainerAPI> apis) {
-        if (null != apis && !apis.isEmpty()) {
-            mAPIS.addAll(apis);
-        }
-    }
-
-    public static Response handle(Request request) {
-        for (RexxarContainerAPI api : mAPIS) {
+        for (RexxarContainerAPI api : containerAPIs) {
             String requestUrl = request.url().toString();
             int fragment = requestUrl.lastIndexOf('#');
             if (fragment > 0) {

--- a/core/src/main/java/com/douban/rexxar/view/RexxarWebView.java
+++ b/core/src/main/java/com/douban/rexxar/view/RexxarWebView.java
@@ -11,6 +11,7 @@ import android.widget.ProgressBar;
 
 import com.douban.rexxar.Constants;
 import com.douban.rexxar.R;
+import com.douban.rexxar.resourceproxy.network.RexxarContainerAPI;
 import com.douban.rexxar.utils.BusProvider;
 
 import java.lang.ref.WeakReference;
@@ -260,6 +261,17 @@ public class RexxarWebView extends FrameLayout implements RexxarWebViewCore.UriL
             return;
         }
         mCore.addRexxarWidget(widget);
+    }
+
+    /**
+     * 自定义container api
+     *
+     * @param containerAPI
+     */
+    public void addContainerApi(RexxarContainerAPI containerAPI) {
+        if (null != containerAPI) {
+            mCore.addContainerApi(containerAPI);
+        }
     }
 
     public void onPageVisible() {

--- a/core/src/main/java/com/douban/rexxar/view/RexxarWebViewCore.java
+++ b/core/src/main/java/com/douban/rexxar/view/RexxarWebViewCore.java
@@ -22,6 +22,7 @@ import com.douban.rexxar.Rexxar;
 import com.douban.rexxar.resourceproxy.cache.CacheEntry;
 import com.douban.rexxar.resourceproxy.cache.CacheHelper;
 import com.douban.rexxar.resourceproxy.network.HtmlHelper;
+import com.douban.rexxar.resourceproxy.network.RexxarContainerAPI;
 import com.douban.rexxar.route.Route;
 import com.douban.rexxar.route.RouteManager;
 import com.douban.rexxar.utils.LogUtils;
@@ -241,6 +242,17 @@ public class RexxarWebViewCore extends SafeWebView {
             return;
         }
         mWebViewClient.addRexxarWidget(widget);
+    }
+
+    /**
+     * 自定义container api
+     *
+     * @param containerAPI
+     */
+    public void addContainerApi(RexxarContainerAPI containerAPI) {
+        if (null != containerAPI) {
+            mWebViewClient.addContainerApi(containerAPI);
+        }
     }
 
     @Override

--- a/sample/src/main/java/com/douban/rexxar/example/FrodoContainerAPIs.java
+++ b/sample/src/main/java/com/douban/rexxar/example/FrodoContainerAPIs.java
@@ -22,12 +22,6 @@ import okhttp3.ResponseBody;
  */
 public class FrodoContainerAPIs {
 
-    public static List<RexxarContainerAPI> sAPIs = new ArrayList<>();
-    static {
-        sAPIs.add(new LocationAPI());
-        sAPIs.add(new LogAPI());
-    }
-
     static Response.Builder newResponseBuilder(Request request) {
         Response.Builder responseBuilder = new Response.Builder();
         responseBuilder.request(request);
@@ -36,7 +30,7 @@ public class FrodoContainerAPIs {
         return responseBuilder;
     }
 
-    static class LocationAPI implements RexxarContainerAPI {
+    public static class LocationAPI implements RexxarContainerAPI {
 
         @Override
         public String getPath() {
@@ -58,7 +52,7 @@ public class FrodoContainerAPIs {
         }
     }
 
-    static class LogAPI implements RexxarContainerAPI {
+    public static class LogAPI implements RexxarContainerAPI {
 
         @Override
         public String getPath() {

--- a/sample/src/main/java/com/douban/rexxar/example/MainApplication.java
+++ b/sample/src/main/java/com/douban/rexxar/example/MainApplication.java
@@ -6,7 +6,6 @@ import android.content.pm.PackageManager;
 
 import com.douban.rexxar.Rexxar;
 import com.douban.rexxar.resourceproxy.ResourceProxy;
-import com.douban.rexxar.resourceproxy.network.RexxarContainerAPIHelper;
 import com.douban.rexxar.route.RouteManager;
 
 import java.util.ArrayList;
@@ -37,8 +36,6 @@ public class MainApplication extends Application {
         RouteManager.getInstance().refreshRoute(null);
         // 设置需要代理的资源
         ResourceProxy.getInstance().addProxyHosts(PROXY_HOSTS);
-        // 设置local api
-        RexxarContainerAPIHelper.registerAPIs(FrodoContainerAPIs.sAPIs);
         // 设置自定义的OkHttpClient
         Rexxar.setOkHttpClient(new OkHttpClient().newBuilder()
                 .retryOnConnectionFailure(true)

--- a/sample/src/main/java/com/douban/rexxar/example/RexxarActivity.java
+++ b/sample/src/main/java/com/douban/rexxar/example/RexxarActivity.java
@@ -64,6 +64,10 @@ public class RexxarActivity extends AppCompatActivity {
         mRexxarWebView.addRexxarWidget(new PullToRefreshWidget());
         mRexxarWebView.addRexxarWidget(new MenuWidget());
 
+        // 设置local api
+        mRexxarWebView.addContainerApi(new FrodoContainerAPIs.LocationAPI());
+        mRexxarWebView.addContainerApi(new FrodoContainerAPIs.LogAPI());
+
         // load uri
         mRexxarWebView.loadUri(uri);
     }


### PR DESCRIPTION
### 目的
有些RexxarContainerAPI是全局有效，比如获取用户信息；也存在一些场景RexxarContainerAPI只针对特定业务逻辑无法针对全局生效，比如在播放器页面获取播放状态。基于这种考虑RexxarContainerAPI支持针对每个webview单独注册会更方便。

### 使用方式

1. 全局的RexxarContainerAPI建议在RexxarView的基类中添加;
2. 局部的RexxarContainerAPI（特定页面才需要）可以在特定的场景下手动添加；

fix https://github.com/douban/rexxar-android/issues/33
